### PR TITLE
Updated to work with Crystal 0.24.2

### DIFF
--- a/src/request_id.cr
+++ b/src/request_id.cr
@@ -11,7 +11,7 @@ module RequestID
     end
 
     def generator : String
-      UUID.random
+      UUID.random().to_s
     end
 
     def call(context)

--- a/src/request_id.cr
+++ b/src/request_id.cr
@@ -11,7 +11,7 @@ module RequestID
     end
 
     def generator : String
-      UUID.random().to_s
+      UUID.random.to_s
     end
 
     def call(context)

--- a/src/request_id.cr
+++ b/src/request_id.cr
@@ -1,5 +1,5 @@
 require "http/server/handler"
-require "secure_random"
+require "uuid"
 
 require "./request_id/*"
 
@@ -11,7 +11,7 @@ module RequestID
     end
 
     def generator : String
-      SecureRandom.uuid
+      UUID.random
     end
 
     def call(context)


### PR DESCRIPTION
Crystal 0.24.2 does not have a "secure_random" module which this relies on to generate a UUID. However, there is a dedicated UUID provided by the newest version of crystal. I implemented the exact same thing with the new UUID module by creating a new v4 UUID and casting it to a string.